### PR TITLE
Add Linux support for automatic Chromedriver download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-This getDriver.py file can be used to automatically install the compatible chrome driver for selenium projects.
-This is mainly to avoid the problem of incompatible chrome browser and chrome driver versions when working on selenium projects.
+This ``getDriver.py`` file can be used to automatically install the compatible
+Chrome/Chromium driver for Selenium projects.
+
+The script now works on both **Windows** and **Linux** machines.  It determines
+the installed browser's major version and downloads the corresponding
+``chromedriver`` executable for the current platform, helping avoid the common
+issue of mismatched browser and driver versions.

--- a/getDriver.py
+++ b/getDriver.py
@@ -1,71 +1,156 @@
-from win32com.client import Dispatch
-import wget
-import requests
+"""Download a matching chromedriver for the installed Chrome browser.
+
+This script can be used by Selenium projects to automatically fetch a
+chromedriver binary whose major version matches the locally installed Google
+Chrome/Chromium browser.  The original version of this file was limited to
+Windows machines.  It relied on ``win32com`` to inspect the installed Chrome
+executable and always downloaded the Windows driver.  Running the script on
+Linux therefore resulted in an ``ImportError`` or an inability to detect the
+browser version.  The updated implementation adds Linux support while keeping
+the original Windows behaviour.
+
+The platform is detected at runtime and the correct download URL and driver
+name are selected automatically.  Chrome's version is determined using
+``win32com`` on Windows and by invoking ``google-chrome --version`` (or similar
+commands) on Linux.
+"""
+
+from __future__ import annotations
+
 import json
-import zipfile
 import os
+import platform
 import shutil
+import subprocess
+import zipfile
 
-def get_version_via_com(filename):
+import requests
+import wget
+
+# ``win32com`` is only available on Windows.  Importing it on other platforms
+# would raise an ImportError and break the script.  The import is therefore done
+# lazily based on the current operating system.
+if platform.system() == "Windows":  # pragma: no cover - platform specific
+    from win32com.client import Dispatch
+
+# Public JSON with download information for chromedriver builds
+CHROME_VERSIONS_URL = (
+    "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"
+)
+
+
+def _get_chrome_version_windows() -> str | None:
+    """Return the full Chrome version on Windows using COM APIs."""
+
     parser = Dispatch("Scripting.FileSystemObject")
-    try:
-        version = parser.GetFileVersion(filename)
-    except Exception:
-        return None
-        
-    jsondata = requests.get(
-        "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"
-    )
-    jsonDic = json.loads(jsondata.text)
-    versions = jsonDic['versions']
-
-    # Only keep the major version (e.g. 116 from 116.0.5845.96)
-    major_version = version.split(".")[0]
-
-    download_url = None
-    for item in versions:
-        # Match the version by its major number
-        if item["version"].startswith(major_version):
-            # Find the Windows 64-bit download entry instead of assuming index 4
-            for download in item["downloads"]["chromedriver"]:
-                if download["platform"] == "win64":
-                    download_url = download["url"]
-                    break
-            if download_url:
-                break
-    if not download_url:
-        return None
-
-    latest_driver_zip = wget.download(download_url,'chromedriver.zip')
-    with zipfile.ZipFile(latest_driver_zip, 'r') as zip_ref:
-        zip_ref.extractall() # you can specify the destination folder path here
-    # delete the zip file downloaded above
-    os.remove(latest_driver_zip)
-
-    shutil.move("./chromedriver-win64/chromedriver.exe", "./chromedriver.exe")
-
-    return major_version
-
-def getChromeDriver():
-    """Ensure a matching chromedriver is available.
-
-    If ``chromedriver.exe`` is not present in the current directory, this
-    function tries known Chrome installation paths and downloads the
-    corresponding driver for the first path that exists.
-    """
-
-    if "chromedriver.exe" in os.listdir():
-        return
-
     paths = [
         r"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
         r"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
     ]
     for path in paths:
-        version = get_version_via_com(path)
+        try:
+            version = parser.GetFileVersion(path)
+        except Exception:  # pragma: no cover - depends on local installation
+            continue
         if version:
-            print(version)
-            return
+            return version
+    return None
 
-    raise FileNotFoundError("Google Chrome not found in default locations")
+
+def _get_chrome_version_linux() -> str | None:
+    """Return the full Chrome/Chromium version on Linux.
+
+    The function tries a set of common Chrome/Chromium executable names and
+    returns the version of the first one that can be executed.
+    """
+
+    commands = [
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium-browser",
+        "chromium",
+    ]
+    for cmd in commands:
+        try:
+            result = subprocess.run(
+                [cmd, "--version"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            continue
+        # Typical output: "Google Chrome 116.0.5845.96"
+        version = result.stdout.strip().split()[-1]
+        if version:
+            return version
+    return None
+
+
+def _download_driver(major_version: str) -> None:
+    """Download and extract the driver for the current platform."""
+
+    jsondata = requests.get(CHROME_VERSIONS_URL)
+    versions = json.loads(jsondata.text)["versions"]
+
+    system = platform.system()
+    if system == "Windows":
+        target_platform = "win64"
+        driver_name = "chromedriver.exe"
+    else:
+        target_platform = "linux64"
+        driver_name = "chromedriver"
+
+    download_url = None
+    for item in versions:
+        if item["version"].startswith(major_version):
+            for download in item["downloads"]["chromedriver"]:
+                if download["platform"] == target_platform:
+                    download_url = download["url"]
+                    break
+            if download_url:
+                break
+    if not download_url:
+        return
+
+    latest_driver_zip = wget.download(download_url, "chromedriver.zip")
+    with zipfile.ZipFile(latest_driver_zip, "r") as zip_ref:
+        zip_ref.extractall()
+    os.remove(latest_driver_zip)
+
+    extracted_dir = f"chromedriver-{target_platform}"
+    shutil.move(os.path.join(extracted_dir, driver_name), driver_name)
+
+    if system != "Windows":
+        # Ensure the binary is executable on Unix systems.
+        os.chmod(driver_name, 0o755)
+
+
+def getChromeDriver() -> None:
+    """Ensure a matching chromedriver executable is present.
+
+    The function determines the installed Chrome/Chromium version, downloads
+    the corresponding driver for the current platform and places it in the
+    current working directory.  If the driver already exists, nothing happens.
+    """
+
+    system = platform.system()
+    driver_name = "chromedriver.exe" if system == "Windows" else "chromedriver"
+    if driver_name in os.listdir():
+        return
+
+    if system == "Windows":
+        version = _get_chrome_version_windows()
+    else:
+        version = _get_chrome_version_linux()
+
+    if not version:
+        raise FileNotFoundError("Google Chrome not found in default locations")
+
+    major_version = version.split(".")[0]
+    _download_driver(major_version)
+
+
+if __name__ == "__main__":
+    getChromeDriver()
 


### PR DESCRIPTION
## Summary
- handle Windows and Linux when determining installed Chrome version
- download platform-appropriate chromedriver and mark executable on Unix
- document cross-platform support in README

## Testing
- `python -m py_compile getDriver.py`
- `pip install requests wget` *(fails: 403 Tunnel connection)*
- `python getDriver.py` *(fails: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68a06b1f63e08320a5a11a31ecbf7c6a